### PR TITLE
Andrew branch - Add Functionality to the sidebar container to respond to resize.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ Run `ng github-pages:deploy` to deploy to GitHub Pages.
 ## Further help
 
 To get more help on the `angular-cli` use `ng help` or go check out the [Angular-CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+
+
+## Contributers
+Kapunahele Wong
+Jon Andrew Davis

--- a/src/app/sidenav/sidenav.component.html
+++ b/src/app/sidenav/sidenav.component.html
@@ -1,6 +1,5 @@
-
-<md-sidenav-container class="sidenav-container">
-  <md-sidenav #sidenav class="sidenav">
+<md-sidenav-container class="sidenav-container" (window:resize)="onResize($event.target.innerWidth)">
+  <md-sidenav #sidenav class="sidenav" opened="{{isSideNavOpen}}">
     <ul class="vertical-menu">
       <li class="menu-heading" (click)="toggleSection1()">Section 1
         <md-icon *ngIf="!section1">keyboard_arrow_right</md-icon>
@@ -51,7 +50,7 @@
     </ul>
   </md-sidenav>
   <div class="sidenav-content">
-    <button class="hamburger" md-button (click)="sidenav.open()"><md-icon>menu</md-icon></button>
+    <button *ngIf="isHamburgerVisible" class="hamburger" md-button (click)="sidenav.open()"><md-icon>menu</md-icon></button>
     <div class="main-content">
       <p>Put content here.</p>
     </div>

--- a/src/app/sidenav/sidenav.component.ts
+++ b/src/app/sidenav/sidenav.component.ts
@@ -8,16 +8,21 @@ import { Component, OnInit } from '@angular/core';
 })
 export class SidenavComponent implements OnInit {
 
-  isSideNavOpen: boolean;
+  public isSideNavOpen: Boolean = false;
+  public isHamburgerVisible: Boolean = false;
+  public windowWidthToOpenSideNav: Number = 600;
+
   section1 = false;
   section1b = false;
   section1c = false;
   section2 = false;
   section3 = false;
 
-  toggleSideNav() {
-
+  onResize(_width) {
+    this.isSideNavOpen = _width > this.windowWidthToOpenSideNav;
+    this.isHamburgerVisible = _width < this.windowWidthToOpenSideNav;
   }
+
   toggleSection1() {
     this.section1 = !this.section1;
   }
@@ -27,8 +32,6 @@ export class SidenavComponent implements OnInit {
   toggleSection1c() {
     this.section1c = !this.section1c;
   }
-
-
   toggleSection2() {
     this.section2 = !this.section2;
   }
@@ -40,6 +43,8 @@ export class SidenavComponent implements OnInit {
   constructor() { }
 
   ngOnInit() {
+    console.log(window.innerWidth);
+    this.onResize(window.innerWidth);
   }
 }
 


### PR DESCRIPTION
This adds functionality to the side bar in the Container to allow it to respond to `resize` events. 

 - If below 600, begin with the sidebar closed
 -If below 600, hamburger opens/closes
 - If it's above 600, we will open the sidebar
 - if it's above 600, we will hide the hamburger iwth `*ng-if`

Final thing you may want to do is disable the `Overlay` by hiding it with a media query when you are above `600`! That way you can't accidently close the sidebar, because you generally always want it open.

( the other route would be to ignore the click event on the overlay, so it stays open, but i think hiding it via css media query would be okay too... you do want the event to work `below 600`.

Varaibles are present to change the 600. Should be clear to see what toggles what. Note: we call resize in the `ngInit` to check out what  we've loaded as. 

Final Note: The `window` binding is safe, as far as my research could tell. This is native Angular functionality 👍 

Hope this helps!